### PR TITLE
Fix issue with symptoms _resetting_ to previous severity

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.7.10" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,16 +64,16 @@ dependencies {
     implementation "androidx.navigation:navigation-ui-ktx:2.5.1"
 
     // Glide - Do not update
-    implementation 'com.github.bumptech.glide:glide:4.10.0'
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.10.0'
-    kapt 'com.github.bumptech.glide:compiler:4.10.0'
+    //implementation 'com.github.bumptech.glide:glide:4.10.0'
+    //annotationProcessor 'com.github.bumptech.glide:compiler:4.10.0'
+    //kapt 'com.github.bumptech.glide:compiler:4.10.0'
 
     // File IO - Do no update, supports below java 7 stuff
     implementation 'commons-io:commons-io:2.5'
     // for flag immutable
     implementation 'androidx.work:work-runtime-ktx:2.7.1'
 
-    //room db
+    //room db - necessary for database interaction
     implementation 'androidx.room:room-runtime:2.4.3'
     implementation 'androidx.room:room-ktx:2.4.3'
     kapt "androidx.room:room-compiler:2.4.3"

--- a/app/src/main/java/com/digitalinterruption/lex/MainActivity.kt
+++ b/app/src/main/java/com/digitalinterruption/lex/MainActivity.kt
@@ -22,8 +22,6 @@ class MainActivity : AppCompatActivity() {
     }
 
     companion object {
-        var month = 0
-        var year = 0
         var date: LocalDateTime = LocalDateTime.now()
     }
 }

--- a/app/src/main/java/com/digitalinterruption/lex/SharedPrefs.kt
+++ b/app/src/main/java/com/digitalinterruption/lex/SharedPrefs.kt
@@ -27,7 +27,6 @@ class SharedPrefs(context: Context) {
 
     }
 
-
     fun setIsPinSet(value: Boolean) {
         sharedPreferences?.edit()?.putBoolean("PIN_CODE_SET", value)?.apply()
     }

--- a/app/src/main/java/com/digitalinterruption/lex/adapters/SymptomsAdapter.kt
+++ b/app/src/main/java/com/digitalinterruption/lex/adapters/SymptomsAdapter.kt
@@ -2,6 +2,7 @@ package com.digitalinterruption.lex.adapters
 
 import android.content.Context
 import android.content.res.ColorStateList
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -136,7 +137,6 @@ class SymptomsAdapter(private val list: ArrayList<SymptomModel>, private val con
             }
 
         }
-
     }
 
     override fun getItemCount(): Int {

--- a/app/src/main/java/com/digitalinterruption/lex/calender/EventObject.java
+++ b/app/src/main/java/com/digitalinterruption/lex/calender/EventObject.java
@@ -1,5 +1,6 @@
 package com.digitalinterruption.lex.calender;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public class EventObject {
@@ -7,18 +8,18 @@ public class EventObject {
     private String message;
     private LocalDateTime date;
     private int color;
-    public EventObject(String message, LocalDateTime date) {
+    public EventObject(String message, LocalDate date) {
         this.message = message;
-        this.date = date;
+        this.date = date.atStartOfDay();
     }
-    public EventObject(int id, String message, LocalDateTime date) {
-        this.date = date;
+    public EventObject(int id, String message, LocalDate date) {
+        this.date = date.atStartOfDay();
         this.message = message;
         this.id = id;
     }
 
-    public EventObject(int id, String message, LocalDateTime date, int color){
-        this.date = date;
+    public EventObject(int id, String message, LocalDate date, int color){
+        this.date = date.atStartOfDay();
         this.message = message;
         this.id = id;
         this.color = color;

--- a/app/src/main/java/com/digitalinterruption/lex/data/EncryptSharedPreferences.kt
+++ b/app/src/main/java/com/digitalinterruption/lex/data/EncryptSharedPreferences.kt
@@ -17,6 +17,7 @@ class EncryptSharedPreferences constructor(context: Context){
         val masterKey = MasterKey.Builder(context)
             .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
             .build()
+
         sharedPreferences = EncryptedSharedPreferences.create(
             context,
             "Lex",

--- a/app/src/main/java/com/digitalinterruption/lex/database/MyDatabase.kt
+++ b/app/src/main/java/com/digitalinterruption/lex/database/MyDatabase.kt
@@ -29,9 +29,9 @@ abstract class MyDatabase : RoomDatabase() {
                     context.applicationContext,
                     MyDatabase::class.java,
                     "lex_database")
-                val factory = SupportFactory(SQLiteDatabase.getBytes(encryptionPW?.toCharArray()))//
+                val factory = SupportFactory(SQLiteDatabase.getBytes(encryptionPW?.toCharArray()))// this bit
                 return instance
-                    .openHelperFactory(factory)
+                    .openHelperFactory(factory) //this bit
                     .enableMultiInstanceInvalidation()
                     .build()
 

--- a/app/src/main/java/com/digitalinterruption/lex/models/DataSymptoms.kt
+++ b/app/src/main/java/com/digitalinterruption/lex/models/DataSymptoms.kt
@@ -3,7 +3,8 @@ package com.digitalinterruption.lex.models
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Entity(tableName = "sym_data_table", indices = [Index(value = ["id"], unique = true)])
-data class DataSymptoms(@PrimaryKey(autoGenerate = true) val id: Int, val date: LocalDateTime?, val symptom: String, val intensity: String)
+data class DataSymptoms(@PrimaryKey(autoGenerate = true) val id: Int, val date: LocalDate?, val symptom: String, val intensity: String)

--- a/app/src/main/java/com/digitalinterruption/lex/models/SymptomModel.kt
+++ b/app/src/main/java/com/digitalinterruption/lex/models/SymptomModel.kt
@@ -3,7 +3,6 @@ package com.digitalinterruption.lex.models
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
-import java.time.LocalDateTime
 
 @Entity(tableName = "sym_table", indices = [Index(value = ["id"], unique = true)])
-data class SymptomModel(@PrimaryKey(autoGenerate = true) val id: Int, val date: String?, val symptom: String?, val intensity: String?)
+data class SymptomModel(@PrimaryKey(autoGenerate = true) val id: Int, val date: String, val symptom: String?, val intensity: String?)


### PR DESCRIPTION
Fix Issue where severity was getting _reset_ when scrolling down the symptoms list.
Clean up symptom dates to be the start of each day and only store date, not date and time as those aren't really tracked in the calendar